### PR TITLE
clicking qbhub returns to home

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import { HamburgerIcon, SettingsIcon, TimeIcon } from '@chakra-ui/icons';
-import { Box, Flex, Heading, IconButton } from '@chakra-ui/react';
+import { Box, Flex, Heading, Link, IconButton } from '@chakra-ui/react';
 import { useLocation } from 'react-router-dom';
 import { useAppDispatch } from '../../app/hooks';
 import { open as openSettings } from '../../Settings/settingsSlice';
@@ -34,7 +34,14 @@ const Header: React.FC = () => {
   return (
     <Box p={3} mb={2}>
       <Flex justify="space-between" align="center">
-        <Heading d="inline">QBHub</Heading>
+        <Link 
+          href={ROUTES.reader.tossup}
+          _hover={{ textDecoration: 'none'}}
+        >
+          <Heading>
+            QBHub
+          </Heading>
+        </Link>
         <Box>
           {renderHistory()}
           <IconButton


### PR DESCRIPTION
resolves: #6 

QBHub, which used to be a "Heading" chakra component, is now a "Link" chakra component. This Link component takes the user back to the /reader/route. 